### PR TITLE
Enhance testing with GitHub Actions and coverage reporting

### DIFF
--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -25,7 +25,9 @@ jobs:
   run-tests:
     name: Run tests
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        python-version: [3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
       - uses: actions/checkout@v4
       - uses: wntrblm/nox@main

--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -39,7 +39,7 @@ jobs:
         run: uv python install
 
       - name: Run tests
-        run: nox -s coverage-${{ matrix.python-version }} -- -vv
+        run: nox -s "coverage-${{ matrix.python-version }}" -- -vv
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -39,7 +39,7 @@ jobs:
         run: uv python install
 
       - name: Run tests
-        run: nox -s "coverage-${{ matrix.python-version }}" -- -vv
+        run: nox -s "coverage-${{ matrix.python-version }}" -- --cov-report=xml -vv
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -39,7 +39,20 @@ jobs:
         run: uv python install
 
       - name: Run tests
-        run: nox -s test -- -vv
+        run: nox -s coverage-${{ matrix.python-version }} -- -vv
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+
+  run-doctests:
+    name: Run doctests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wntrblm/nox@main
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Run doctest
         run: nox -s doctest -- -vv

--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11, 3.12, 3.13]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: wntrblm/nox@main

--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -23,7 +23,7 @@ jobs:
         run: uv run pre-commit run --all-files --show-diff-on-failure
 
   run-tests:
-    name: Run tests
+    name: Run tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/noxfile.py
+++ b/noxfile.py
@@ -101,7 +101,7 @@ def coverage(session: nox.Session) -> None:
     print("Coverage HTML report: file://htmlcov/index.html")
 
 
-# ---- Documentation ----
+# ==================== DOCUMENTATION ====================
 
 
 @nox.session(venv_backend="uv", tags=[DOCS_TAG])

--- a/noxfile.py
+++ b/noxfile.py
@@ -89,7 +89,9 @@ def doctest_docs(session: nox.Session) -> None:
     )
 
 
-@nox.session(venv_backend="uv", tags=[TEST_TAG])
+@nox.session(
+    venv_backend="uv", tags=[TEST_TAG], python=["3.9", "3.10", "3.11", "3.12", "3.13"]
+)
 def coverage(session: nox.Session) -> None:
     """Run tests with coverage reporting."""
     _run_install(session)

--- a/noxfile.py
+++ b/noxfile.py
@@ -95,10 +95,9 @@ def doctest_docs(session: nox.Session) -> None:
 def coverage(session: nox.Session) -> None:
     """Run tests with coverage reporting."""
     _run_install(session)
-    session.install("coverage[toml]")
-    session.run("coverage", "run", "-m", "pytest", *session.posargs)
-    session.run("coverage", "report", "-m")
-    session.run("coverage", "html")
+    session.run(
+        "pytest", "--cov=src/tagkit", "cov-branch", "--cov-report=xml", *session.posargs
+    )
     print("Coverage HTML report: file://htmlcov/index.html")
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -96,7 +96,10 @@ def coverage(session: nox.Session) -> None:
     """Run tests with coverage reporting."""
     _run_install(session)
     session.run(
-        "pytest", "--cov=src/tagkit", "cov-branch", "--cov-report=xml", *session.posargs
+        "pytest",
+        "--cov=src/tagkit",
+        "--cov-branch",
+        *session.posargs,
     )
     print("Coverage HTML report: file://htmlcov/index.html")
 


### PR DESCRIPTION
Implement a matrix strategy for Python versions in GitHub Actions, utilize pytest-cov for coverage reporting, and integrate Codecov for coverage uploads. Split doctests into a separate job for better organization.