### PR TITLE
Don't run no-commit-to-branch in CI

### DIFF
--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -26,7 +26,7 @@ jobs:
         run: uv python install
 
       - name: Run checks
-        run: uv run pre-commit run --all-files --show-diff-on-failure
+        run: uv run pre-commit run --all-files --hook-stage push --show-diff-on-failure
 
   run-tests:
     name: Run tests (Python ${{ matrix.python-version }})

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
       - id: trailing-whitespace
       - id: no-commit-to-branch
         args: [--branch, main]
+        stages: [commit]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0


### PR DESCRIPTION
The CI configuration has been updated to prevent the no-commit-to-branch hook from running during continuous integration. This change allows legitimate merge commits on the main branch without triggering failures.

Fixes #29