### PR TITLE
Add dynamic version lookup fallback

### DIFF
--- a/src/tagkit/__init__.py
+++ b/src/tagkit/__init__.py
@@ -1,7 +1,11 @@
-import importlib.metadata
+import importlib.metadata as _importlib_metadata
 
-__version__ = importlib.metadata.version(__name__)
+try:
+    __version__ = _importlib_metadata.version(__name__)
+except _importlib_metadata.PackageNotFoundError:
+    # editable/dev installs won't have package metadata
+    __version__ = "0+unknown"
 
 from tagkit.image import ExifImageCollection, ExifImage
 
-__all__ = ["ExifImageCollection", "ExifImage"]
+__all__ = ["ExifImageCollection", "ExifImage", "__version__"]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,10 @@
+from importlib.metadata import PackageNotFoundError
+
+from unittest.mock import patch
+
+
+def test_failed_version_lookup():
+    with patch("importlib.metadata.version", side_effect=PackageNotFoundError):
+        import tagkit
+
+        assert tagkit.__version__ == "0+unknown"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,5 @@
 from importlib.metadata import PackageNotFoundError
-
+import importlib
 from unittest.mock import patch
 
 
@@ -7,4 +7,5 @@ def test_failed_version_lookup():
     with patch("importlib.metadata.version", side_effect=PackageNotFoundError):
         import tagkit
 
+        importlib.reload(tagkit)
         assert tagkit.__version__ == "0+unknown"


### PR DESCRIPTION
This pull request updates the way the package version is set in `src/tagkit/__init__.py`, making it more robust for development and editable installs. It also improves module exports.

Version handling improvements:

* The import of `importlib.metadata` is now aliased as `_importlib_metadata` for clarity.
* The assignment of `__version__` is wrapped in a try/except block to handle cases where package metadata is missing (such as in editable or development installs), defaulting to `"0+unknown"` if the version cannot be found.

Module export changes:

* The `__all__` list now includes `__version__` alongside `ExifImageCollection` and `ExifImage`, making the version available when using `from tagkit import *`.