### PR TITLE
Add IFD-aware registry definitions

### DIFF
--- a/src/tagkit/conf/models.py
+++ b/src/tagkit/conf/models.py
@@ -20,9 +20,101 @@ class RegistryTagEntry(BaseModel):
     """Entry for a single EXIF tag in the registry."""
 
     name: str = Field(description="Tag name (e.g., 'Make', 'Model')")
-    type: Literal[
-        "ASCII", "BYTE", "RATIONAL", "SRATIONAL", "SHORT", "LONG", "UNDEFINED", "FLOAT"
-    ] = Field(description="EXIF data type")
+    type: Union[
+        Literal[
+            "ASCII",
+            "BYTE",
+            "FLOAT",
+            "LONG",
+            "RATIONAL",
+            "SHORT",
+            "SRATIONAL",
+            "UNDEFINED",
+        ],
+        list[
+            Literal[
+                "ASCII",
+                "BYTE",
+                "FLOAT",
+                "LONG",
+                "RATIONAL",
+                "SHORT",
+                "SRATIONAL",
+                "UNDEFINED",
+            ]
+        ],
+    ] = Field(description="Allowed EXIF data type or types")
+    count: Union[int, Literal["any"], None] = Field(
+        default=None,
+        description="Expected EXIF component count, or 'any' for variable count",
+    )
+
+    @field_validator("type")
+    @classmethod
+    def validate_type_list(
+        cls,
+        v: Union[
+            Literal[
+                "ASCII",
+                "BYTE",
+                "FLOAT",
+                "LONG",
+                "RATIONAL",
+                "SHORT",
+                "SRATIONAL",
+                "UNDEFINED",
+            ],
+            list[
+                Literal[
+                    "ASCII",
+                    "BYTE",
+                    "FLOAT",
+                    "LONG",
+                    "RATIONAL",
+                    "SHORT",
+                    "SRATIONAL",
+                    "UNDEFINED",
+                ]
+            ],
+        ],
+    ) -> Union[
+        Literal[
+            "ASCII",
+            "BYTE",
+            "FLOAT",
+            "LONG",
+            "RATIONAL",
+            "SHORT",
+            "SRATIONAL",
+            "UNDEFINED",
+        ],
+        list[
+            Literal[
+                "ASCII",
+                "BYTE",
+                "FLOAT",
+                "LONG",
+                "RATIONAL",
+                "SHORT",
+                "SRATIONAL",
+                "UNDEFINED",
+            ]
+        ],
+    ]:
+        """Validate that multi-type definitions are not empty."""
+        if isinstance(v, list) and not v:
+            raise ValueError("type list must contain at least one EXIF type")
+        return v
+
+    @field_validator("count")
+    @classmethod
+    def validate_count(
+        cls, v: Union[int, Literal["any"], None]
+    ) -> Union[int, Literal["any"], None]:
+        """Validate fixed counts are positive."""
+        if isinstance(v, int) and v <= 0:
+            raise ValueError("count must be a positive integer or 'any'")
+        return v
 
     model_config = {"extra": "forbid"}
 

--- a/src/tagkit/core/exceptions.py
+++ b/src/tagkit/core/exceptions.py
@@ -73,6 +73,17 @@ class InvalidTagId(TagkitError):
         super().__init__(msg)
 
 
+class AmbiguousTagKey(TagkitError):
+    """Raised when a tag name or ID matches more than one IFD definition."""
+
+    def __init__(self, tag_key: Union[int, str], matches: Iterable[str]) -> None:
+        match_list = ", ".join(matches)
+        super().__init__(
+            f"Ambiguous tag key '{tag_key}' matches multiple IFD definitions: "
+            f"{match_list}. Provide an explicit ifd."
+        )
+
+
 class TagNotFound(TagkitError):
     """Raised when a specified tag is not found in an image.
 

--- a/src/tagkit/core/formatting.py
+++ b/src/tagkit/core/formatting.py
@@ -8,7 +8,9 @@ according to configuration rules.
 import base64
 import math
 from pathlib import Path
-from typing import Any, Callable, Optional, Self, TYPE_CHECKING, Union, cast
+from typing import Any, Callable, Optional, TYPE_CHECKING, Union, cast
+
+from typing_extensions import Self
 
 import yaml
 
@@ -47,7 +49,7 @@ class ValueFormatter:
         'f/1.2'
 
         # Bytes
-        >>> tag_entry = ExifTag(1, b'\\xff\\xfe\\xfd\\xfc', 'Exif')
+        >>> tag_entry = ExifTag(37510, b'\\xff\\xfe\\xfd\\xfc', 'Exif')
         >>> formatter.format_value(tag_entry)
         '<bytes: 4>'
 

--- a/src/tagkit/core/registry.py
+++ b/src/tagkit/core/registry.py
@@ -2,27 +2,60 @@
 Registry of EXIF tags and their metadata.
 
 This module provides the ExifRegistry class which maintains information about
-all supported EXIF tags, their IDs, names, and types.
+supported EXIF tags, their IFD-aware identities, names, types, and counts.
 """
 
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Optional, Self, TypedDict, Union
+from typing import Literal, TypedDict, Union
+
+from typing_extensions import Self
 
 import yaml
-import warnings
 
 from tagkit.conf.models import RegistryConfig
-from tagkit.core.exceptions import InvalidTagId, InvalidTagName
-from tagkit.core.types import ExifType, IfdName
+from tagkit.core.exceptions import AmbiguousTagKey, InvalidTagId, InvalidTagName
+from tagkit.core.types import ExifCount, ExifType, IfdName
 
 
-class RegistryConfValue(TypedDict):
+class RegistryConfValue(TypedDict, total=False):
     name: str
-    type: ExifType
+    type: ExifType | list[ExifType]
+    count: ExifCount | None
 
 
 RegistryConfKey = Literal["Image", "Exif", "GPS", "Interop"]
 RegistryConf = dict[RegistryConfKey, dict[int, RegistryConfValue]]
+
+
+@dataclass(frozen=True)
+class ExifTagDefinition:
+    """IFD-aware EXIF tag definition."""
+
+    ifd: IfdName
+    tag_id: int
+    name: str
+    allowed_types: tuple[ExifType, ...]
+    count: ExifCount | None = None
+
+    @property
+    def exif_type(self) -> ExifType:
+        """Return the primary EXIF type for compatibility helpers."""
+        return self.allowed_types[0]
+
+
+def _registry_ifd_to_tagkit_ifd(ifd: RegistryConfKey) -> IfdName:
+    return "IFD0" if ifd == "Image" else ifd
+
+
+def _tagkit_ifd_to_registry_ifd(ifd: IfdName) -> RegistryConfKey:
+    if ifd in ("IFD0", "IFD1"):
+        return "Image"
+    if ifd == "Exif":
+        return "Exif"
+    if ifd == "GPS":
+        return "GPS"
+    return "Interop"
 
 
 class ExifRegistry:
@@ -30,22 +63,39 @@ class ExifRegistry:
     Registry of all EXIF tags compatible with tagkit.
 
     Args:
-        registry_conf (RegistryConf): The EXIF tag registry configuration.
+        registry_conf: The EXIF tag registry configuration.
     """
 
     def __init__(self, registry_conf: RegistryConf):
         self.tags_by_ifd = registry_conf
 
-        name_to_id = {}
-        name_to_type = {}
-        for ifd_tags in self.tags_by_ifd.values():
-            name_to_id.update({tag["name"]: tag_id for tag_id, tag in ifd_tags.items()})
-            name_to_type.update({tag["name"]: tag["type"] for tag in ifd_tags.values()})
-        self._name_to_id = name_to_id
-        self._name_to_type = name_to_type
-        self._tag_ids = {
-            tag_id for exif_tags in registry_conf.values() for tag_id in exif_tags
-        }
+        self._definitions_by_key: dict[
+            tuple[RegistryConfKey, int], ExifTagDefinition
+        ] = {}
+        self._definitions_by_name: dict[str, list[ExifTagDefinition]] = {}
+        self._definitions_by_id: dict[int, list[ExifTagDefinition]] = {}
+
+        for registry_ifd, ifd_tags in self.tags_by_ifd.items():
+            tagkit_ifd = _registry_ifd_to_tagkit_ifd(registry_ifd)
+            for tag_id, tag in ifd_tags.items():
+                raw_type = tag["type"]
+                allowed_types = (
+                    tuple(raw_type) if isinstance(raw_type, list) else (raw_type,)
+                )
+                definition = ExifTagDefinition(
+                    ifd=tagkit_ifd,
+                    tag_id=tag_id,
+                    name=tag["name"],
+                    allowed_types=allowed_types,
+                    count=tag.get("count"),
+                )
+                self._definitions_by_key[registry_ifd, tag_id] = definition
+                self._definitions_by_name.setdefault(definition.name, []).append(
+                    definition
+                )
+                self._definitions_by_id.setdefault(definition.tag_id, []).append(
+                    definition
+                )
 
     @classmethod
     def from_yaml(cls, path: Union[Path, str, None] = None) -> Self:
@@ -53,213 +103,147 @@ class ExifRegistry:
         Load the EXIF tag registry from a YAML file.
 
         Args:
-            path (Union[Path, str, None]): Path to the YAML file. If None, uses default.
+            path: Path to the YAML file. If None, uses default.
 
         Returns:
-            ExifRegistry: The loaded registry instance.
-
-        Raises:
-            FileNotFoundError: If the YAML file does not exist.
-            yaml.YAMLError: If the YAML file is invalid.
-            pydantic.ValidationError: If the YAML structure is invalid.
+            The loaded registry instance.
         """
         if path is None:
-            here = Path(__file__).parents[1]  # Go up to tagkit package root
+            here = Path(__file__).parents[1]
             path = here / "conf/registry.yaml"
         with open(path, "r") as f:
             raw_conf = yaml.safe_load(f)
 
-        # Validate with Pydantic
         validated_conf = RegistryConfig.model_validate(raw_conf)
-
-        # Convert to the format expected by __init__
-        # exclude_defaults=True removes empty IFD sections (which have default empty dicts)
         conf: RegistryConf = validated_conf.model_dump(exclude_defaults=True)  # type: ignore
         return cls(conf)
 
     @property
     def tag_names(self) -> list[str]:
         """
-        List all tag names in the registry.
+        List all unique tag names in the registry.
 
         Returns:
-            list[str]: All tag names.
-
-        Example:
-            >>> tag_registry.tag_names[:5]
-            ['ProcessingSoftware', 'NewSubfileType', 'SubfileType', 'ImageWidth', 'ImageLength']
+            All tag names.
         """
-        return list(self._name_to_id)
+        return list(self._definitions_by_name)
+
+    def get_definition(
+        self, tag_key: Union[int, str], ifd: IfdName | None = None
+    ) -> ExifTagDefinition:
+        """
+        Resolve an IFD-aware tag definition.
+
+        If ``ifd`` is omitted, the lookup succeeds only when the tag key maps to
+        exactly one definition.
+        """
+        if ifd is not None:
+            registry_ifd = _tagkit_ifd_to_registry_ifd(ifd)
+            tag_id = self.resolve_tag_id(tag_key, ifd=ifd)
+            try:
+                definition = self._definitions_by_key[registry_ifd, tag_id]
+            except KeyError:
+                if isinstance(tag_key, int):
+                    raise InvalidTagId(tag_key) from None
+                raise InvalidTagName(tag_key) from None
+            if ifd == "IFD1":
+                return ExifTagDefinition(
+                    ifd="IFD1",
+                    tag_id=definition.tag_id,
+                    name=definition.name,
+                    allowed_types=definition.allowed_types,
+                    count=definition.count,
+                )
+            return definition
+
+        matches = (
+            self._definitions_by_id.get(tag_key, [])
+            if isinstance(tag_key, int)
+            else self._definitions_by_name.get(tag_key, [])
+        )
+        if not matches:
+            if isinstance(tag_key, int):
+                raise InvalidTagId(tag_key)
+            raise InvalidTagName(tag_key)
+        if len(matches) > 1:
+            raise AmbiguousTagKey(
+                tag_key,
+                [f"{match.ifd}:{match.tag_id} ({match.name})" for match in matches],
+            )
+        return matches[0]
 
     def get_ifd(self, tag_key: Union[int, str], thumbnail: bool = False) -> IfdName:
         """
-        Get the IFD (Image File Directory) for a tag. If a tag id is provided that is
-        present in multiple IFDs, a warning is raised and the first found IFD is
-        returned. IFD's are searched in the order of IFD0, Exif, GPS, Interop. If
-        the thumbnail argument is True, IFD1 is always returned.
+        Get the IFD for an unambiguous tag.
 
         Args:
-            tag_key (Union[int, str]): Tag name or tag ID.
-            thumbnail (bool): If True, return the thumbnail IFD (IFD1).
-
-        Returns:
-            IfdName: The IFD name.
-
-        Raises:
-            ValueError: If the tag or IFD is invalid.
-
-        Example:
-            >>> tag_registry.get_ifd('Make')
-            'IFD0'
+            tag_key: Tag name or tag ID.
+            thumbnail: If True, return the thumbnail IFD (IFD1).
         """
-        self._validate_tag_key(tag_key)
-
         if thumbnail:
+            self._validate_tag_key(tag_key)
             return "IFD1"
+        return self.get_definition(tag_key).ifd
 
-        found_ifds: list[Literal["IFD0", "Exif", "GPS", "Interop"]] = []
-        ifd0: Literal["IFD0"] = "IFD0"
-        for ifd_category, tags in self.tags_by_ifd.items():
-            tag_names = [tag["name"] for tag in tags.values()]
-            if tag_key in tag_names or tag_key in tags:
-                ifd = ifd0 if ifd_category == "Image" else ifd_category
-                found_ifds.append(ifd)
-        if len(found_ifds) > 1:
-            warnings.warn(f"Tag ID {tag_key} found in multiple IFDs: {found_ifds}")
-        if found_ifds:
-            return found_ifds[0]
-
-        # Execution shouldn't make it this far because if tag_key is in self
-        # then there should always be a result. However, as a guardrail we
-        # raise here anyway.
-        raise ValueError(f"Could not find ifd for tag '{tag_key}'")
-
-    def resolve_tag_id(self, tag_key: Union[int, str]) -> int:
+    def resolve_tag_id(
+        self, tag_key: Union[int, str], ifd: IfdName | None = None
+    ) -> int:
         """
-        Get tag ID for a given tag name or return the ID unchanged if already an int.
-
-        Args:
-            tag_key (Union[int, str]): Tag name or tag ID.
-
-        Returns:
-            int: Tag ID for the given tag name.
-
-        Raises:
-            InvalidTagName: If the tag name is invalid.
-            InvalidTagId: If the tag ID is invalid.
-
-        Example:
-            >>> tag_registry.resolve_tag_id('Make')
-            271
+        Get a tag ID for a tag name or return an unambiguous integer ID.
         """
         if isinstance(tag_key, int):
-            self._validate_tag_id(tag_key)
-            return tag_key
+            if ifd is not None:
+                registry_ifd = _tagkit_ifd_to_registry_ifd(ifd)
+                if (registry_ifd, tag_key) not in self._definitions_by_key:
+                    raise InvalidTagId(tag_key)
+                return tag_key
+            return self.get_definition(tag_key).tag_id
 
-        self._validate_tag_name(tag_key)
-        return self._name_to_id[tag_key]
+        matches = self._definitions_by_name.get(tag_key, [])
+        if not matches:
+            raise InvalidTagName(tag_key)
+        if ifd is not None:
+            registry_ifd = _tagkit_ifd_to_registry_ifd(ifd)
+            for definition in matches:
+                if _tagkit_ifd_to_registry_ifd(definition.ifd) == registry_ifd:
+                    return definition.tag_id
+            raise InvalidTagName(tag_key)
+        if len(matches) > 1:
+            raise AmbiguousTagKey(
+                tag_key,
+                [f"{match.ifd}:{match.tag_id} ({match.name})" for match in matches],
+            )
+        return matches[0].tag_id
 
     def resolve_tag_name(
-        self, tag_key: Union[int, str], ifd: Optional[IfdName] = None
+        self, tag_key: Union[int, str], ifd: IfdName | None = None
     ) -> str:
         """
-        Get tag name for a given tag name or tag ID. If given a tag ID, returns the name.
-
-        Args:
-            tag_key (Union[int, str]): Tag name or tag ID.
-            ifd (Optional[IfdName]): Specific IFD to use.
-
-        Returns:
-            str: Tag name for the given tag ID.
-
-        Raises:
-            InvalidTagName: If the tag name is invalid.
-            InvalidTagId: If the tag ID is invalid.
-            ValueError: If the tag or IFD is invalid.
-
-        Example:
-            >>> tag_registry.resolve_tag_name(271)
-            'Make'
+        Get a tag name for a tag ID or return an unambiguous tag name.
         """
-        if isinstance(tag_key, str):
-            self._validate_tag_name(tag_key)
-            return tag_key
+        return self.get_definition(tag_key, ifd=ifd).name
 
-        self._validate_tag_id(tag_key)
-
-        ifd_key = "Image" if ifd in ("IFD0", "IFD1") else ifd
-
-        if ifd_key is not None:
-            return self.tags_by_ifd[ifd_key][tag_key]["name"]  # type: ignore
-
-        # If IFD not given then try all IFD's
-        for ifd_tags in self.tags_by_ifd.values():
-            if tag_key in ifd_tags:
-                return ifd_tags[tag_key]["name"]
-
-        # Execution shouldn't make it this far because if tag_id is in self
-        # then there should always be a result. However, as a guardrail we
-        # raise here anyway.
-        raise ValueError(f"Could not find ifd for tag '{tag_key}'")
+    def get_exif_type(
+        self, tag_key: Union[int, str], ifd: IfdName | None = None
+    ) -> ExifType:
+        """
+        Get the primary EXIF type for a tag.
+        """
+        return self.get_definition(tag_key, ifd=ifd).exif_type
 
     def _validate_tag_key(self, tag_key: Union[int, str]) -> None:
-        """
-        Validate the tag key (either ID or name).
-
-        Args:
-            tag_key (Union[int, str]): Tag name or tag ID.
-
-        Raises:
-            InvalidTagName: If the tag name is invalid.
-            InvalidTagId: If the tag ID is invalid.
-        """
         if isinstance(tag_key, int):
             self._validate_tag_id(tag_key)
         else:
             self._validate_tag_name(tag_key)
 
     def _validate_tag_id(self, tag_id: int) -> None:
-        if tag_id not in self._tag_ids:
+        if tag_id not in self._definitions_by_id:
             raise InvalidTagId(tag_id)
 
     def _validate_tag_name(self, tag_name: str) -> None:
-        if tag_name not in self._name_to_id:
+        if tag_name not in self._definitions_by_name:
             raise InvalidTagName(tag_name)
 
-    def get_exif_type(self, tag_key: Union[int, str]) -> ExifType:
-        """
-        Get the EXIF type for a tag.
 
-        Args:
-            tag_key (Union[int, str]): Tag name or tag ID.
-
-        Returns:
-            ExifType: The EXIF type for the tag.
-
-        Raises:
-            InvalidTagName: If the tag name is invalid.
-            InvalidTagId: If the tag ID is invalid.
-
-        Example:
-            >>> tag_registry.get_exif_type('Make')
-            'ASCII'
-        """
-        if isinstance(tag_key, str):
-            self._validate_tag_name(tag_key)
-            return self._name_to_type[tag_key]
-
-        self._validate_tag_id(tag_key)
-
-        # Find the tag in any IFD
-        for ifd_tags in self.tags_by_ifd.values():
-            if tag_key in ifd_tags:
-                return ifd_tags[tag_key]["type"]
-
-        # Execution shouldn't make it this far because if tag_id is in self
-        # then there should always be a result. However, as a guardrail we
-        # raise here anyway.
-        raise ValueError(f"Could not find type for tag '{tag_key}'")
-
-
-# Create a singleton instance
 tag_registry = ExifRegistry.from_yaml()

--- a/src/tagkit/core/tag.py
+++ b/src/tagkit/core/tag.py
@@ -34,12 +34,12 @@ class ExifTag:
     @property
     def name(self) -> str:
         """Get the human-readable name of this tag."""
-        return tag_registry.resolve_tag_name(self.id)
+        return tag_registry.resolve_tag_name(self.id, ifd=self.ifd)
 
     @property
     def exif_type(self) -> ExifType:
         """Get the EXIF data type of this tag."""
-        return tag_registry.get_exif_type(self.id)
+        return tag_registry.get_exif_type(self.id, ifd=self.ifd)
 
     def format(self, binary_format: Optional[str] = None) -> str:
         """

--- a/src/tagkit/core/types.py
+++ b/src/tagkit/core/types.py
@@ -28,7 +28,17 @@ TagValue = Union[
     RationalCollection,
 ]
 ExifIfdCollection = dict[str, dict[int, TagValue]]
-ExifType = Literal["ASCII", "BYTE", "RATIONAL", "SRATIONAL", "SHORT", "UNDEFINED"]
+ExifType = Literal[
+    "ASCII",
+    "BYTE",
+    "FLOAT",
+    "LONG",
+    "RATIONAL",
+    "SHORT",
+    "SRATIONAL",
+    "UNDEFINED",
+]
+ExifCount = Union[int, Literal["any"]]
 IfdName = Literal["IFD0", "IFD1", "Exif", "GPS", "Interop"]
 
 

--- a/src/tagkit/image/collection.py
+++ b/src/tagkit/image/collection.py
@@ -454,8 +454,8 @@ class ExifImageCollection:
         # Pre-resolve tag names; respect skip_missing for invalid tags
         resolved_tags: list[tuple[Union[str, int], str]] = []
         for tag_key in tag_keys:
-            tag_name = tag_registry.resolve_tag_name(tag_key)
-            resolved_tags.append((tag_key, tag_name))
+            definition = tag_registry.get_definition(tag_key, ifd=ifd)
+            resolved_tags.append((tag_key, definition.name))
 
         result: dict[str, dict[str, TagValue]] = {}
         for fname in targets:

--- a/src/tagkit/image/exif.py
+++ b/src/tagkit/image/exif.py
@@ -56,7 +56,17 @@ class ExifImage:
 
     def __len__(self) -> int:
         """Return the number of tags in this image."""
-        return len(self.tags)
+        tag_filter_set = (
+            {tag_registry.resolve_tag_id(tag, ifd=self.ifd) for tag in self.tag_filter}
+            if self.tag_filter is not None
+            else None
+        )
+        return sum(
+            1
+            for (tag_id, ifd) in self._tag_dict
+            if (tag_filter_set is None or tag_id in tag_filter_set)
+            and (self.ifd is None or ifd == self.ifd)
+        )
 
     def write_tag(
         self,
@@ -82,7 +92,7 @@ class ExifImage:
         """
         if ifd is None:
             ifd = tag_registry.get_ifd(tag_key)
-        tag_id = tag_registry.resolve_tag_id(tag_key)
+        tag_id = tag_registry.resolve_tag_id(tag_key, ifd=ifd)
         self._tag_dict[tag_id, ifd] = ExifTag(tag_id, value, ifd)
 
     def write_tags(
@@ -123,9 +133,9 @@ class ExifImage:
             >>> exif = ExifImage('image10.jpg')
             >>> exif.delete_tag('Make', ifd='IFD0')
         """
-        tag_id = tag_registry.resolve_tag_id(tag_key)
         if ifd is None:
-            ifd = tag_registry.get_ifd(tag_id)
+            ifd = tag_registry.get_ifd(tag_key)
+        tag_id = tag_registry.resolve_tag_id(tag_key, ifd=ifd)
         # Only delete if present; do not raise if missing
         if (tag_id, ifd) in self._tag_dict:
             del self._tag_dict[tag_id, ifd]
@@ -190,13 +200,13 @@ class ExifImage:
                 "binary_format must be one of 'bytes', 'hex', 'base64' or None"
             )
 
-        tag_id = tag_registry.resolve_tag_id(tag_key)
         if ifd is None:
-            ifd = tag_registry.get_ifd(tag_id)
+            ifd = tag_registry.get_ifd(tag_key)
+        tag_id = tag_registry.resolve_tag_id(tag_key, ifd=ifd)
 
         # Check if tag exists in the image
         if (tag_id, ifd) not in self._tag_dict:
-            tag_name = tag_registry.resolve_tag_name(tag_id)
+            tag_name = tag_registry.resolve_tag_name(tag_id, ifd=ifd)
             raise TagNotFound(tag_name)
 
         exif_tag = self._tag_dict[tag_id, ifd]
@@ -246,7 +256,7 @@ class ExifImage:
         result: dict[str, TagValue] = {}
 
         for tag_key in tag_keys:
-            tag_name = tag_registry.resolve_tag_name(tag_key)
+            tag_name = tag_registry.get_definition(tag_key, ifd=ifd).name
             try:
                 value = self.read_tag(
                     tag_key,
@@ -270,13 +280,13 @@ class ExifImage:
             dict: A dictionary of filtered tags with tag names as keys.
         """
         tag_filter_set = (
-            {tag_registry.resolve_tag_id(tag) for tag in self.tag_filter}
+            {tag_registry.resolve_tag_id(tag, ifd=self.ifd) for tag in self.tag_filter}
             if self.tag_filter is not None
             else None
         )
 
         return {
-            tag_registry.resolve_tag_name(tag_id): tag
+            tag_registry.resolve_tag_name(tag_id, ifd=ifd): tag
             for (tag_id, ifd), tag in self._tag_dict.items()
             if (tag_filter_set is None or tag_id in tag_filter_set)
             and (self.ifd is None or ifd == self.ifd)

--- a/src/tagkit/tag_io/piexif_io.py
+++ b/src/tagkit/tag_io/piexif_io.py
@@ -1,4 +1,4 @@
-from typing import Union, cast
+from typing import cast
 import piexif
 
 from tagkit.tag_io.base import ExifIOBackend, ExifTagDict
@@ -31,11 +31,8 @@ class PiexifBackend(ExifIOBackend):
         for ifd, ifd_tags in conformed_dict.items():
             for tag_id, val in ifd_tags.items():
                 # Decode if ascii
-                val = (
-                    cast(bytes, val).decode(STR_ENCODING)
-                    if _tag_is_ascii(tag_id)
-                    else val
-                )
+                if _tag_is_ascii(tag_id, ifd) and isinstance(val, bytes):
+                    val = val.decode(STR_ENCODING)
                 result_dict[tag_id, ifd] = ExifTag(tag_id, val, ifd)
 
         return ExifTagDict(result_dict)
@@ -69,7 +66,7 @@ class PiexifBackend(ExifIOBackend):
 
             # Prepare the tag value - encode strings for ASCII tags
             tag_value = tag.value
-            if _tag_is_ascii(tag.id) and isinstance(tag_value, str):
+            if _tag_is_ascii(tag) and isinstance(tag_value, str):
                 tag_value = cast(str, tag_value).encode(STR_ENCODING)
 
             # Add the tag to the piexif data structure
@@ -82,10 +79,11 @@ class PiexifBackend(ExifIOBackend):
         piexif.insert(exif_bytes, str(image_path))
 
 
-def _tag_is_ascii(tag: Union[ExifTag, int]) -> bool:
+def _tag_is_ascii(tag: ExifTag | int, ifd: IfdName | None = None) -> bool:
     if isinstance(tag, ExifTag):
+        ifd = tag.ifd
         tag = tag.id
-    return tag_registry.get_exif_type(tag) == "ASCII"
+    return tag_registry.get_exif_type(tag, ifd=ifd) == "ASCII"
 
 
 def _conform_ifd_names(raw_piexif: PiexifTags) -> dict[IfdName, dict[int, TagValue]]:

--- a/tests/core/test_tag_registry.py
+++ b/tests/core/test_tag_registry.py
@@ -1,9 +1,7 @@
 import pytest
 from pathlib import Path
-import warnings
-
 from tagkit.core.registry import ExifRegistry, tag_registry
-from tagkit.core.exceptions import InvalidTagId, InvalidTagName
+from tagkit.core.exceptions import AmbiguousTagKey, InvalidTagId, InvalidTagName
 from tagkit.core.types import ExifType
 
 
@@ -36,8 +34,7 @@ def registry(sample_registry_conf):
 def test_init(registry, sample_registry_conf):
     """Test registry initialization"""
     assert registry.tags_by_ifd == sample_registry_conf
-    assert len(registry._name_to_id) == 7  # Total unique tag names
-    assert len(registry._tag_ids) == 6  # Total unique tag IDs
+    assert len(registry.tag_names) == 7  # Total unique tag names
 
 
 def test_from_yaml():
@@ -175,11 +172,18 @@ def test_get_exif_type_invalid_name(registry):
 
 
 def test_get_ifd_warns_on_multiple_ifds():
-    # Create a registry with a tag in multiple IFDs
     conf = {
         "Image": {123: {"name": "TestTag", "type": "ASCII"}},
         "Exif": {123: {"name": "TestTag", "type": "ASCII"}},
     }  # type: ignore
     reg = ExifRegistry(conf)  # type: ignore
-    with pytest.warns(UserWarning, match="multiple IFDs"):
+    with pytest.raises(AmbiguousTagKey, match="Provide an explicit ifd"):
         reg.get_ifd(123)
+
+
+def test_get_definition_by_ambiguous_id_requires_ifd(registry):
+    with pytest.raises(AmbiguousTagKey):
+        registry.get_definition(1)
+    definition = registry.get_definition(1, ifd="GPS")
+    assert definition.name == "GPSLatitudeRef"
+    assert definition.ifd == "GPS"

--- a/tests/core/test_value_formatting.py
+++ b/tests/core/test_value_formatting.py
@@ -119,24 +119,24 @@ def test_format_value(formatter: ValueFormatter):
 
 
 def test_format_value_with_bytes_base64(formatter: ValueFormatter):
-    tag = ExifTag(id=1, value=b"\xff\xfe\xfd\xfc", ifd="Exif")
+    tag = ExifTag(id=37510, value=b"\xff\xfe\xfd\xfc", ifd="Exif")
     assert formatter.format_value(tag, binary_format="base64") == "base64://79/A=="
 
 
 def test_format_value_with_bytes_hex(formatter: ValueFormatter):
-    tag = ExifTag(id=1, value=b"\xff\xfe\xfd\xfc", ifd="Exif")
+    tag = ExifTag(id=37510, value=b"\xff\xfe\xfd\xfc", ifd="Exif")
     assert formatter.format_value(tag, binary_format="hex") == "hex:fffefdfc"
 
 
 def test_format_value_with_bytes_bytes(formatter: ValueFormatter):
-    tag = ExifTag(id=1, value=b"\xff\xfe\xfd\xfc", ifd="Exif")
+    tag = ExifTag(id=37510, value=b"\xff\xfe\xfd\xfc", ifd="Exif")
     assert (
         formatter.format_value(tag, binary_format="bytes") == "b'\\xff\\xfe\\xfd\\xfc'"
     )
 
 
 def test_format_value_with_bytes_no_render(formatter: ValueFormatter):
-    tag = ExifTag(id=1, value=b"\xff\xfe\xfd\xfc", ifd="Exif")
+    tag = ExifTag(id=37510, value=b"\xff\xfe\xfd\xfc", ifd="Exif")
     assert formatter.format_value(tag, binary_format=None) == "<bytes: 4>"
 
 

--- a/tests/tag_io/test_piexif_io.py
+++ b/tests/tag_io/test_piexif_io.py
@@ -27,7 +27,7 @@ def test_tag_is_ascii():
     entry = ExifTag(271, "Canon", "IFD0")
     assert _tag_is_ascii(entry) is True
     # 33434 is 'ExposureTime', which is RATIONAL
-    assert _tag_is_ascii(33434) is False
+    assert _tag_is_ascii(33434, "Exif") is False
 
 
 def test_load_tags_and_save_tags():

--- a/tests/test_conf_schemas.py
+++ b/tests/test_conf_schemas.py
@@ -107,6 +107,40 @@ def test_registry_invalid_type():
         RegistryConfig.model_validate(invalid_data)
 
 
+def test_registry_accepts_count_and_multi_type():
+    """Test that registry entries can define count and multiple allowed types."""
+    data = {
+        "Image": {
+            256: {
+                "name": "ImageWidth",
+                "type": ["SHORT", "LONG"],
+                "count": 1,
+            },
+            271: {
+                "name": "Make",
+                "type": "ASCII",
+                "count": "any",
+            },
+        }
+    }
+    RegistryConfig.model_validate(data)
+
+
+def test_registry_rejects_invalid_count():
+    """Test that malformed count definitions are rejected."""
+    invalid_data = {
+        "Image": {
+            271: {
+                "name": "Make",
+                "type": "ASCII",
+                "count": 0,
+            }
+        }
+    }
+    with pytest.raises(ValidationError, match="count must be a positive integer"):
+        RegistryConfig.model_validate(invalid_data)
+
+
 def test_registry_missing_name():
     """Test that missing tag name is rejected."""
     invalid_data = {


### PR DESCRIPTION
## Summary
- add an IFD-aware ExifTagDefinition model and registry lookup path
- raise explicit ambiguity errors instead of choosing the first matching IFD
- make ExifTag and the piexif backend resolve metadata with IFD context
- extend registry schema support for count and multi-type definitions

## Issues
- Starts #56
- Covers #57
- Starts #58
- Starts #61

## Tests
- uv run pytest tests/core/test_tag_registry.py tests/test_conf_schemas.py tests/tag_io/test_piexif_io.py tests/core/test_value_formatting.py -q