### PR TITLE
Add IFD-aware API and write validation

### DIFF
--- a/src/tagkit/core/validation.py
+++ b/src/tagkit/core/validation.py
@@ -1,0 +1,193 @@
+"""Validation helpers for EXIF-shaped tag values."""
+
+from collections.abc import Sequence
+from typing import Any, cast
+
+from tagkit.core.exceptions import ValidationError
+from tagkit.core.registry import ExifTagDefinition
+from tagkit.core.types import ExifCount, ExifType, Rational, TagValue
+
+
+def validate_tag_value(definition: ExifTagDefinition, value: TagValue) -> TagValue:
+    """
+    Validate and structurally normalize a tag value for a definition.
+
+    The low-level write API expects EXIF-shaped values. This function only
+    converts lists to tuples when the resulting shape is otherwise valid.
+    """
+    normalized = _normalize_sequences(value)
+    errors: list[str] = []
+    for exif_type in definition.allowed_types:
+        try:
+            return _validate_for_type(definition, normalized, exif_type)
+        except ValidationError as exc:
+            errors.append(str(exc))
+
+    expected = _format_expected(definition)
+    received = f"{type(value).__name__}: {value!r}"
+    raise ValidationError(
+        f"Invalid value for {definition.name} "
+        f"(IFD {definition.ifd}, tag ID {definition.tag_id}). "
+        f"Expected {expected}; received {received}. "
+        f"Details: {'; '.join(errors)}"
+    )
+
+
+def _normalize_sequences(value: Any) -> Any:
+    if isinstance(value, list):
+        return tuple(_normalize_sequences(item) for item in value)
+    if isinstance(value, tuple):
+        return tuple(_normalize_sequences(item) for item in value)
+    return value
+
+
+def _validate_for_type(
+    definition: ExifTagDefinition, value: Any, exif_type: ExifType
+) -> TagValue:
+    if exif_type == "ASCII":
+        if not isinstance(value, str):
+            raise ValidationError("ASCII values must be str")
+        _validate_ascii_count(definition.count, value)
+        return value
+
+    if exif_type == "UNDEFINED":
+        if not isinstance(value, bytes):
+            raise ValidationError("UNDEFINED values must be bytes")
+        _validate_count(definition.count, len(value))
+        return value
+
+    if exif_type == "BYTE":
+        return _validate_integer_value(definition.count, value, 0, 255, "BYTE")
+
+    if exif_type == "SHORT":
+        return _validate_integer_value(definition.count, value, 0, 65535, "SHORT")
+
+    if exif_type == "LONG":
+        return _validate_integer_value(definition.count, value, 0, 4294967295, "LONG")
+
+    if exif_type == "RATIONAL":
+        return _validate_rational_value(definition.count, value, signed=False)
+
+    if exif_type == "SRATIONAL":
+        return _validate_rational_value(definition.count, value, signed=True)
+
+    if exif_type == "FLOAT":
+        return _validate_float_value(definition.count, value)
+
+    raise ValidationError(f"unsupported EXIF type {exif_type}")
+
+
+def _validate_ascii_count(count: ExifCount | None, value: str) -> None:
+    if count is None or count == "any":
+        return
+    _validate_count(count, len(value) + 1)
+
+
+def _validate_integer_value(
+    count: ExifCount | None, value: Any, minimum: int, maximum: int, label: str
+) -> TagValue:
+    if isinstance(value, bool):
+        raise ValidationError(f"{label} scalar must be int")
+    if isinstance(value, int):
+        _validate_count(count, 1)
+        _validate_integer_range(value, minimum, maximum, label)
+        return value
+    if _is_plain_sequence(value):
+        values = tuple(value)
+        _validate_count(count, len(values))
+        for item in values:
+            if isinstance(item, bool) or not isinstance(item, int):
+                raise ValidationError(f"{label} sequences must contain only ints")
+            _validate_integer_range(item, minimum, maximum, label)
+        return values
+    raise ValidationError(f"{label} value must be int or tuple[int, ...]")
+
+
+def _validate_float_value(count: ExifCount | None, value: Any) -> TagValue:
+    if isinstance(value, bool):
+        raise ValidationError("FLOAT scalar must be int or float")
+    if isinstance(value, (int, float)):
+        _validate_count(count, 1)
+        return float(value)
+    if _is_plain_sequence(value):
+        values = tuple(value)
+        _validate_count(count, len(values))
+        if any(
+            isinstance(item, bool) or not isinstance(item, (int, float))
+            for item in values
+        ):
+            raise ValidationError(
+                "FLOAT sequences must contain only int or float values"
+            )
+        return tuple(float(item) for item in values)
+    raise ValidationError("FLOAT value must be float or tuple[float, ...]")
+
+
+def _validate_rational_value(
+    count: ExifCount | None, value: Any, *, signed: bool
+) -> TagValue:
+    if _is_rational(value):
+        _validate_count(count, 1)
+        rational = cast(Rational, value)
+        _validate_rational_components(rational, signed=signed)
+        return rational
+    if _is_plain_sequence(value):
+        values = tuple(value)
+        if not values or not all(_is_rational(item) for item in values):
+            raise ValidationError("rational sequences must contain rational tuples")
+        _validate_count(count, len(values))
+        rationals = cast(tuple[Rational, ...], values)
+        for rational in rationals:
+            _validate_rational_components(rational, signed=signed)
+        return rationals
+    raise ValidationError(
+        "rational value must be tuple[int, int] or tuple of rationals"
+    )
+
+
+def _validate_rational_components(rational: Rational, *, signed: bool) -> None:
+    numerator, denominator = rational
+    if isinstance(numerator, bool) or isinstance(denominator, bool):
+        raise ValidationError("rational components must be ints")
+    if not isinstance(numerator, int) or not isinstance(denominator, int):
+        raise ValidationError("rational components must be ints")
+    if denominator == 0:
+        raise ValidationError("rational denominator must not be zero")
+    if not signed and (numerator < 0 or denominator < 0):
+        raise ValidationError("RATIONAL components must be non-negative")
+
+
+def _validate_integer_range(value: int, minimum: int, maximum: int, label: str) -> None:
+    if value < minimum or value > maximum:
+        raise ValidationError(
+            f"{label} value {value} outside range {minimum}..{maximum}"
+        )
+
+
+def _validate_count(count: ExifCount | None, actual: int) -> None:
+    if count is None or count == "any":
+        return
+    if actual != count:
+        raise ValidationError(f"count {actual} does not match expected count {count}")
+
+
+def _is_rational(value: Any) -> bool:
+    return (
+        isinstance(value, tuple)
+        and len(value) == 2
+        and all(isinstance(item, int) and not isinstance(item, bool) for item in value)
+    )
+
+
+def _is_plain_sequence(value: Any) -> bool:
+    return (
+        isinstance(value, Sequence)
+        and not isinstance(value, (bytes, str))
+        and not _is_rational(value)
+    )
+
+
+def _format_expected(definition: ExifTagDefinition) -> str:
+    types = " or ".join(definition.allowed_types)
+    count = "unspecified" if definition.count is None else definition.count
+    return f"type {types}, count {count}"

--- a/src/tagkit/image/exif.py
+++ b/src/tagkit/image/exif.py
@@ -8,11 +8,12 @@ image files.
 from datetime import datetime, timedelta
 from typing import Iterable, Optional, Union, Mapping
 
-from tagkit.core.exceptions import TagNotFound, DateTimeError
+from tagkit.core.exceptions import AmbiguousTagKey, TagNotFound, DateTimeError
 from tagkit.core.datetime_utils import format_exif_datetime, parse_exif_datetime
 from tagkit.core.registry import tag_registry
 from tagkit.core.tag import ExifTag
 from tagkit.core.types import TagValue, FilePath, IfdName
+from tagkit.core.validation import validate_tag_value
 from tagkit.tag_io.base import ExifIOBackend
 from tagkit.tag_io.piexif_io import PiexifBackend
 
@@ -56,17 +57,7 @@ class ExifImage:
 
     def __len__(self) -> int:
         """Return the number of tags in this image."""
-        tag_filter_set = (
-            {tag_registry.resolve_tag_id(tag, ifd=self.ifd) for tag in self.tag_filter}
-            if self.tag_filter is not None
-            else None
-        )
-        return sum(
-            1
-            for (tag_id, ifd) in self._tag_dict
-            if (tag_filter_set is None or tag_id in tag_filter_set)
-            and (self.ifd is None or ifd == self.ifd)
-        )
+        return len(self.tag_entries)
 
     def write_tag(
         self,
@@ -90,10 +81,13 @@ class ExifImage:
             >>> exif = ExifImage('image1.jpg')
             >>> exif.write_tag('Artist', 'John Doe', ifd='IFD0')
         """
-        if ifd is None:
-            ifd = tag_registry.get_ifd(tag_key)
-        tag_id = tag_registry.resolve_tag_id(tag_key, ifd=ifd)
-        self._tag_dict[tag_id, ifd] = ExifTag(tag_id, value, ifd)
+        definition = tag_registry.get_definition(tag_key, ifd=ifd)
+        normalized_value = validate_tag_value(definition, value)
+        self._tag_dict[definition.tag_id, definition.ifd] = ExifTag(
+            definition.tag_id,
+            normalized_value,
+            definition.ifd,
+        )
 
     def write_tags(
         self,
@@ -133,9 +127,9 @@ class ExifImage:
             >>> exif = ExifImage('image10.jpg')
             >>> exif.delete_tag('Make', ifd='IFD0')
         """
-        if ifd is None:
-            ifd = tag_registry.get_ifd(tag_key)
-        tag_id = tag_registry.resolve_tag_id(tag_key, ifd=ifd)
+        definition = tag_registry.get_definition(tag_key, ifd=ifd)
+        tag_id = definition.tag_id
+        ifd = definition.ifd
         # Only delete if present; do not raise if missing
         if (tag_id, ifd) in self._tag_dict:
             del self._tag_dict[tag_id, ifd]
@@ -200,14 +194,13 @@ class ExifImage:
                 "binary_format must be one of 'bytes', 'hex', 'base64' or None"
             )
 
-        if ifd is None:
-            ifd = tag_registry.get_ifd(tag_key)
-        tag_id = tag_registry.resolve_tag_id(tag_key, ifd=ifd)
+        definition = tag_registry.get_definition(tag_key, ifd=ifd)
+        tag_id = definition.tag_id
+        ifd = definition.ifd
 
         # Check if tag exists in the image
         if (tag_id, ifd) not in self._tag_dict:
-            tag_name = tag_registry.resolve_tag_name(tag_id, ifd=ifd)
-            raise TagNotFound(tag_name)
+            raise TagNotFound(definition.name)
 
         exif_tag = self._tag_dict[tag_id, ifd]
 
@@ -256,7 +249,7 @@ class ExifImage:
         result: dict[str, TagValue] = {}
 
         for tag_key in tag_keys:
-            tag_name = tag_registry.get_definition(tag_key, ifd=ifd).name
+            definition = tag_registry.get_definition(tag_key, ifd=ifd)
             try:
                 value = self.read_tag(
                     tag_key,
@@ -264,12 +257,36 @@ class ExifImage:
                     format_value=format_value,
                     binary_format=binary_format,
                 )
-                result[tag_name] = value
+                result[definition.name] = value
             except TagNotFound:
                 if skip_missing:
                     continue
                 raise
         return result
+
+    @property
+    def tag_entries(self) -> Mapping[tuple[IfdName, int], ExifTag]:
+        """
+        Get filtered tags keyed by canonical ``(ifd, tag_id)`` identity.
+
+        Returns:
+            Mapping of IFD-aware tag keys to tags.
+        """
+        tag_filter_set = (
+            {
+                tag_registry.get_definition(tag, ifd=self.ifd).tag_id
+                for tag in self.tag_filter
+            }
+            if self.tag_filter is not None
+            else None
+        )
+
+        return {
+            (ifd, tag_id): tag
+            for (tag_id, ifd), tag in self._tag_dict.items()
+            if (tag_filter_set is None or tag_id in tag_filter_set)
+            and (self.ifd is None or ifd == self.ifd)
+        }
 
     @property
     def tags(self) -> Mapping[str, ExifTag]:
@@ -279,18 +296,19 @@ class ExifImage:
         Returns:
             dict: A dictionary of filtered tags with tag names as keys.
         """
-        tag_filter_set = (
-            {tag_registry.resolve_tag_id(tag, ifd=self.ifd) for tag in self.tag_filter}
-            if self.tag_filter is not None
-            else None
-        )
-
-        return {
-            tag_registry.resolve_tag_name(tag_id, ifd=ifd): tag
-            for (tag_id, ifd), tag in self._tag_dict.items()
-            if (tag_filter_set is None or tag_id in tag_filter_set)
-            and (self.ifd is None or ifd == self.ifd)
-        }
+        result: dict[str, ExifTag] = {}
+        for (ifd, tag_id), tag in self.tag_entries.items():
+            tag_name = tag_registry.resolve_tag_name(tag_id, ifd=ifd)
+            if tag_name in result:
+                raise AmbiguousTagKey(
+                    tag_name,
+                    [
+                        f"{result[tag_name].ifd}:{result[tag_name].id}",
+                        f"{tag.ifd}:{tag.id}",
+                    ],
+                )
+            result[tag_name] = tag
+        return result
 
     def save(self, create_backup: bool = False):
         """

--- a/tests/image/test_exif_image.py
+++ b/tests/image/test_exif_image.py
@@ -8,10 +8,12 @@ from pathlib import Path
 from tagkit import ExifImage
 from tagkit.core.tag import ExifTag
 from tagkit.core.exceptions import (
+    AmbiguousTagKey,
     DateTimeError,
     InvalidTagId,
     InvalidTagName,
     TagNotFound,
+    ValidationError,
 )
 from tagkit.core.types import TagValue
 
@@ -41,6 +43,14 @@ def test_tags_property_with_ifd(test_images):
     tags = exif.tags
     # All returned tags should be from IFD0
     assert all(tag.ifd == "IFD0" for tag in tags.values())
+
+
+def test_tag_entries_uses_canonical_ifd_id_keys(test_images):
+    """Canonical tag access is keyed by (ifd, tag_id)."""
+    exif = ExifImage(test_images / "minimal.jpg")
+    entries = exif.tag_entries
+    assert ("IFD0", 271) in entries
+    assert entries["IFD0", 271].name == "Make"
 
 
 def test_tags_property_with_thumbnail(test_images):
@@ -166,13 +176,70 @@ def test_write_tags_multiple_tags(test_images, file_type: Callable):
     """Test writing multiple tags at once with both str and Path file_path types."""
     tags: dict[Union[str, int], TagValue] = {
         "Artist": "Jane Doe",
-        "Copyright": b"2025 John",
+        "Copyright": "2025 John",
     }
     file_path = file_type(test_images / "minimal.jpg")
     exif = ExifImage(file_path)
     exif.write_tags(tags)
     assert exif.tags["Artist"].value == "Jane Doe"
-    assert exif.tags["Copyright"].value == b"2025 John"
+    assert exif.tags["Copyright"].value == "2025 John"
+
+
+def test_write_ascii_tag_rejects_bytes(test_images):
+    """Low-level writes reject bytes for ASCII tags."""
+    exif = ExifImage(test_images / "minimal.jpg")
+    with pytest.raises(ValidationError, match="ASCII values must be str"):
+        exif.write_tag("Copyright", b"2025 John")
+    assert "Copyright" not in exif.tags
+
+
+def test_ambiguous_low_level_lookup_requires_ifd(test_images):
+    """Ambiguous IDs or names require an explicit IFD."""
+    exif = ExifImage(test_images / "with_gps.jpg")
+    with pytest.raises(AmbiguousTagKey):
+        exif.read_tag(1)
+    assert exif.read_tag(1, ifd="GPS") == "N"
+
+
+def test_write_gps_coordinate_normalizes_lists(test_images):
+    """Generic list-to-tuple normalization is allowed for exact EXIF shapes."""
+    exif = ExifImage(test_images / "minimal.jpg")
+    exif.write_tag("GPSLatitude", [[40, 1], [44, 1], [52, 1]])
+    assert exif.read_tag("GPSLatitude") == ((40, 1), (44, 1), (52, 1))
+
+
+def test_write_gps_coordinate_rejects_wrong_count_without_mutation(test_images):
+    """Invalid fixed-count writes fail before mutating existing values."""
+    exif = ExifImage(test_images / "minimal.jpg")
+    original = ((40, 1), (44, 1), (52, 1))
+    exif.write_tag("GPSLatitude", original)
+    with pytest.raises(ValidationError, match="expected count 3"):
+        exif.write_tag("GPSLatitude", ((40, 1), (44, 1)))
+    assert exif.read_tag("GPSLatitude") == original
+
+
+def test_write_rejects_semantic_float_to_rational_coercion(test_images):
+    """Low-level writes do not coerce semantic float values to rationals."""
+    exif = ExifImage(test_images / "minimal.jpg")
+    with pytest.raises(ValidationError, match="rational value"):
+        exif.write_tag("GPSAltitude", 10.5)
+
+
+def test_write_fixed_count_rational_sequence(test_images):
+    """Fixed-count rational sequence tags enforce their declared count."""
+    exif = ExifImage(test_images / "minimal.jpg")
+    value = ((0, 1), (255, 1), (0, 1), (255, 1), (0, 1), (255, 1))
+    exif.write_tag("ReferenceBlackWhite", value)
+    assert exif.read_tag("ReferenceBlackWhite") == value
+    with pytest.raises(ValidationError, match="expected count 6"):
+        exif.write_tag("ReferenceBlackWhite", value[:4])
+
+
+def test_ambiguous_duplicate_name_requires_ifd(test_images):
+    """Duplicate names across IFDs do not silently choose a definition."""
+    exif = ExifImage(test_images / "minimal.jpg")
+    with pytest.raises(AmbiguousTagKey):
+        exif.write_tag("CFAPattern", b"\x00\x01")
 
 
 @pytest.mark.parametrize("file_type", [str, Path])

--- a/tests/image/test_exif_image_collection.py
+++ b/tests/image/test_exif_image_collection.py
@@ -146,13 +146,13 @@ class TestImageCollection:
         files = [f"foo_{i}" for i in range(2)]
         tags: dict[Union[str, int], TagValue] = {
             "Artist": "Jane Doe",
-            "Copyright": b"2025 John",
+            "Copyright": "2025 John",
         }
         collection = ExifImageCollection(files)
         collection.write_tags(tags)
         for fname in files:
             assert collection.files[fname].tags["Artist"].value == "Jane Doe"
-            assert collection.files[fname].tags["Copyright"].value == b"2025 John"
+            assert collection.files[fname].tags["Copyright"].value == "2025 John"
 
     @pytest.mark.parametrize("file_type", [str, Path])
     def test_write_tags_selected_files(self, mock_exif_w_patch: dict, file_type):


### PR DESCRIPTION
## Summary
- add canonical ExifImage.tag_entries keyed by (ifd, tag_id)
- route read/write/delete paths through IFD-aware definitions
- add strict low-level write validation before mutating tags
- allow only structural list-to-tuple normalization, not semantic coercions
- update collection behavior and regression tests

## Issues
- Continues #56
- Covers #60
- Covers #62
- Covers #63 API/validation portions
- Covers #61 API/backend follow-through
- Closes #48 when merged with stack

## Tests
- uv run pytest tests/image/test_exif_image.py tests/image/test_exif_image_collection.py -q
- uv run pytest tests/core/test_tag_registry.py tests/tag_io/test_piexif_io.py tests/test_conf_schemas.py -q