### PR TITLE
Document 0.4.0 EXIF model migration

### DIFF
--- a/docs/source/development/contributing.md
+++ b/docs/source/development/contributing.md
@@ -125,6 +125,10 @@ All configuration files in the project are validated using [Pydantic](https://do
 2. Run `uv run pytest tests/test_conf_schemas.py` to validate all configs
 3. Update the Pydantic models if you need to change the schema
 
+Registry entries include a tag `name`, one EXIF `type` or a list of allowed
+types, and optional `count` metadata. Use a positive integer for fixed-count
+tags and `any` for variable-count values.
+
 The validation happens automatically when configs are loaded and during CI testing.
 
 ## Pre-commit Hooks

--- a/docs/source/development/development_guide.md
+++ b/docs/source/development/development_guide.md
@@ -93,7 +93,9 @@ src/tagkit/
 
 To add support for a new tag:
 
-1. Update the tag registry configuration in `conf/registry.yaml`.
+1. Update the tag registry configuration in `conf/registry.yaml`, including
+   the tag name, EXIF type or allowed types, and count metadata when the tag is
+   writable or otherwise validated.
 2. If needed, add custom formatting in `core/formatting.py` and register it in the configuration (`conf/formatting.yaml`).
 
 ## Testing

--- a/docs/source/user_guide/reading.md
+++ b/docs/source/user_guide/reading.md
@@ -57,8 +57,19 @@ exif = ExifImage("image1.jpg")
 tags = exif.tags
 
 # Print all tags
-for tag_id, tag in tags.items():
+for tag_name, tag in tags.items():
     print(f"{tag.name}: {tag.value}")
+```
+
+`exif.tags` is a convenience view keyed by tag name. For EXIF-correct access that can always represent duplicate names and IDs across IFDs, use `exif.tag_entries`, which is keyed by `(ifd, tag_id)`:
+
+```{testcode}
+from tagkit.image.exif import ExifImage
+
+exif = ExifImage("image1.jpg")
+
+for (ifd, tag_id), tag in exif.tag_entries.items():
+    print(f"{ifd}:{tag_id} {tag.name}: {tag.value}")
 ```
 
 ### Reading Specific Tags

--- a/docs/source/user_guide/writing.md
+++ b/docs/source/user_guide/writing.md
@@ -11,15 +11,12 @@ Writing tag values via the CLI is not yet supported.
 ### Writing Single Tags
 
 Use the `write_tag` method to write a single tag to an image. You can specify the tag by name or integer ID, along with its value. If the tag does not exist, it will be created.
-You may specify an explicit IFD (Image File Directory) using the `ifd` argument. If not specified, the IFD is determined based on the tag name or ID. For tags associated with both the main and thumbnail IFDs, the main IFD is used by default unless the `thumbnail` argument is set to `True`.
+You may specify an explicit IFD (Image File Directory) using the `ifd` argument. If not specified, the tag name or ID must resolve to exactly one EXIF definition.
 If the tag already exists, it will be updated with the new value.
 
-If a tag id or tag name is provided that is present in both the main and thumbnail IFDs, the tag will be written to the main IFD only unless you specify `ifd='IFD1'`. If a tag id or tag name
-is provided that is present in two other IFDs and the ifd is not specified, the tag
-will be written to the first IFD that contains the tag and a warning is emitted.
-IFD's are searched in the order of IFD0, Exif, GPS, Interop. In general, there is much
-less chance of overlap when specifying tags by name rather than by ID, but explicitly
-specifying the IFD eliminates this issue.
+Some EXIF tag IDs and names appear in more than one IFD. Low-level calls now raise an ambiguity error for those tags unless you pass `ifd`. For example, tag ID `1` exists in both GPS and Interop metadata, so use `exif.write_tag(1, "N", ifd="GPS")` rather than `exif.write_tag(1, "N")`.
+
+Low-level writes expect EXIF-shaped values. Tagkit validates the value type, numeric range, rational shape, and count before changing the in-memory tag. Generic structural normalization is allowed, such as converting JSON-style lists to tuples, but semantic conversions belong in higher-level helpers. For example, pass `(105, 10)` for `GPSAltitude`, not `10.5`; pass `"N"` for `GPSLatitudeRef`, not `b"N"`.
 
 **Note:** Changes are not saved to disk until you call the `save()` method.
 
@@ -55,7 +52,7 @@ exif = ExifImage("image1.jpg")
 # Write multiple tags (in-memory)
 tags_to_write = {
     "Artist": "Jane Doe",
-    "Copyright": "© 2025 Jane Doe"
+    "Copyright": "2025 Jane Doe"
 }
 exif.write_tags(tags_to_write)
 


### PR DESCRIPTION
## Summary
- document canonical tag_entries access for duplicate-safe EXIF reads
- update writing docs for ambiguous low-level lookups and strict EXIF-shaped values
- note registry schema expectations for future tag additions

## Issues
- Completes #56
- Covers #64
- Covers #63 docs/coverage follow-through

## Tests
- uv run pytest -q
- uv run nox --reuse-existing-virtualenvs -s check
- uv run nox --reuse-existing-virtualenvs -s docs
- uv run nox --reuse-existing-virtualenvs -s doctest_docs